### PR TITLE
Set of example schemas that are not FULL_TRANSITIVE

### DIFF
--- a/tests/fixtures/transitive1.json
+++ b/tests/fixtures/transitive1.json
@@ -1,0 +1,15 @@
+{
+    "type": "record",
+    "name": "test",
+    "fields": [
+      {
+        "type": "string",
+        "name": "field1"
+      },
+      {
+        "type": "string",
+        "name": "field2",
+        "default": "foo"
+      }
+    ]
+  }

--- a/tests/fixtures/transitive2.json
+++ b/tests/fixtures/transitive2.json
@@ -1,0 +1,10 @@
+{
+    "type": "record",
+    "name": "test",
+    "fields": [
+      {
+        "type": "string",
+        "name": "field1"
+      }
+    ]
+  }

--- a/tests/fixtures/transitive3.json
+++ b/tests/fixtures/transitive3.json
@@ -1,0 +1,15 @@
+{
+    "type": "record",
+    "name": "test",
+    "fields": [
+      {
+        "type": "string",
+        "name": "field1"
+      },
+      {
+        "type": "int",
+        "name": "field2",
+        "default": "0"
+      }
+    ]
+  }


### PR DESCRIPTION
This example uses an optional column that is then removed (hey it's optional!). After that we add a column with the same name but different type - this is compatible with the previous schema but not ALL versions of the schema.